### PR TITLE
Hotfix 0.1.1 - fix Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,8 @@ node{
         } else {
             target = 'package'
         }
-        if (env.BRANCH_NAME.contains('-') && env.BRANCH_NAME.split('-')[0] in ['feature', 'fix', 'hotfix']) {
+        // env.BRANCH_NAME null if tag
+        if (env.BRANCH_NAME && env.BRANCH_NAME.contains('-') && env.BRANCH_NAME.split('-')[0] in ['feature', 'fix', 'hotfix']) {
             branchSuffix = env.BRANCH_NAME.substring(env.BRANCH_NAME.indexOf('-') + 1)
         }
         List versionSuffixes = []

--- a/pom.xml
+++ b/pom.xml
@@ -337,9 +337,9 @@
 	</build>
 
 	<scm>
-		<url>git@github.com:openwide-java/bindgen.git</url>
-		<connection>scm:git:git@github.com:openwide-java/bindgen.git</connection>
-		<developerConnection>scm:git:git@github.com:openwide-java/bindgen.git</developerConnection>
+		<url>git@github.com:openwide-java/bindgen-java.git</url>
+		<connection>scm:git:git@github.com:openwide-java/bindgen-java.git</connection>
+		<developerConnection>scm:git:git@github.com:openwide-java/bindgen-java.git</developerConnection>
 		<tag>HEAD</tag>
 	</scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>fr.openwide.core.components</groupId>
 	<artifactId>bindgen-java</artifactId>
-	<version>0.1.0</version>
+	<version>0.1.1-SNAPSHOT</version>
 	
 	<name>owsi-core java.* bindings</name>
 	<description>Pre-generated bindings for java classes</description>


### PR DESCRIPTION
env.BRANCH_NAME can be null when tag is checked out. Modified Jenkinsfile allow to do deploy via a Jenkins pipeline job.